### PR TITLE
Fix CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,27 +44,6 @@ jobs:
           paths:
             - ~/.m2
 
-  coverage:
-    executor: clojure
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - v1-coverage-{{ checksum "project.clj" }}
-            - v1-coverage-
-            - v1-test-
-      - run: lein cloverage --codecov
-      - save_cache:
-          key: v1-coverage-{{ checksum "project.clj" }}
-          paths:
-            - ~/.m2
-      - store_artifacts:
-          path: target/coverage
-          destination: coverage
-      - run:
-          name: Publish Coverage
-          command: 'bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json'
-
 
 # Workflow definitions
 workflows:
@@ -73,6 +52,3 @@ workflows:
     jobs:
       - style
       - test
-      - coverage:
-          requires:
-            - test

--- a/src/vault/client/ext/aws.clj
+++ b/src/vault/client/ext/aws.clj
@@ -68,8 +68,8 @@
 (defn- str->b64str
   [^java.util.Base64$Encoder b64 ^String s]
   (-> s
-    (.getBytes "UTF-8")
-    (->> (.encodeToString b64))))
+      (.getBytes "UTF-8")
+      (->> (.encodeToString b64))))
 
 
 (defn- request-parameters


### PR DESCRIPTION
`cljstyle fix` and remove cloverage.

The cloverage build always fails, I think because the project has no
tests, so I'm removing it.

I had to twiddle some bits in CircleCI to get this building for some
reason, so I didn't test this before submitting #3. (I thought CircleCI not
running was due to the GitHub service degredation this morning but that
was not the case.)